### PR TITLE
Make nginx usable with Symfony2

### DIFF
--- a/templates/nginx/default
+++ b/templates/nginx/default
@@ -41,7 +41,7 @@ server {
 
     [[ if (.Container.GetCustomValue "fastCgi")]]
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-    location ~ \.php$ {
+    location ~ \.php(/|$) {
            fastcgi_split_path_info ^(.+\.php)(/.+)$;
 
            fastcgi_pass ${[[ (.Container.GetCustomValue "fastCgi") | ToUpper ]]_PORT_[[ (.Collection.Get .Container.Custom.fastCgi ).GetFirstPort ]]_TCP_ADDR}:${[[ (.Container.GetCustomValue "fastCgi") | ToUpper ]]_PORT_[[ (.Collection.Get .Container.Custom.fastCgi ).GetFirstPort]]_TCP_PORT};


### PR DESCRIPTION
In order to use nginx in front of a Symfony2 php-fpm app, I've added support for documentRoot (like in apache) and made paths like `app.php/hello` passed to fastCgi.
